### PR TITLE
Increase /var to >=80Gb free to meet installation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,4 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [chef-automate-ha](#chef-automate-ha)
-  - [Deployment Outcomes](#deployment-outcomes)
-  - [Prerequisites](#prerequisites)
-  - [Installation Instructions](#installation-instructions)
-    - [1. Create Service Principal [optional]](#1-create-service-principal-optional)
-    - [2. Customize azuredeploy.parameters file](#2-customize-azuredeployparameters-file)
-    - [3. Create Resource Group for solution](#3-create-resource-group-for-solution)
-    - [4. Execute the template deployment](#4-execute-the-template-deployment)
-  - [Post-Installation and Verification](#post-installation-and-verification)
-  - [Further information](#further-information)
-  - [Licensing](#licensing)
-  - [Contact](#contact)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # chef-automate-ha
 
@@ -35,6 +18,24 @@ Date:   Tue Jun 12 14:16:14 2018 -0500
     Update mainTemplateTests.js
 ```
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+## Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [chef-automate-ha](#chef-automate-ha)
+  - [Deployment Outcomes](#deployment-outcomes)
+  - [Prerequisites](#prerequisites)
+  - [Installation Instructions](#installation-instructions)
+    - [1. Create Service Principal [optional]](#1-create-service-principal-optional)
+    - [2. Customize azuredeploy.parameters file](#2-customize-azuredeployparameters-file)
+    - [3. Create Resource Group for solution](#3-create-resource-group-for-solution)
+    - [4. Execute the template deployment](#4-execute-the-template-deployment)
+  - [Post-Installation and Verification](#post-installation-and-verification)
+  - [Further information](#further-information)
+  - [Licensing](#licensing)
+  - [Contact](#contact)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Deployment Outcomes
 
 After deploying this template into your subscription, you will have deployed the reference Chef HA architecture, similar to[https://docs.chef.io/install_server_ha.html](https://docs.chef.io/install_server_ha.html):

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Date:   Tue Jun 12 14:16:14 2018 -0500
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-## Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+## Table of Contents
 
 - [chef-automate-ha](#chef-automate-ha)
   - [Deployment Outcomes](#deployment-outcomes)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [chef-automate-ha](#chef-automate-ha)
+  - [Deployment Outcomes](#deployment-outcomes)
+  - [Prerequisites](#prerequisites)
+  - [Installation Instructions](#installation-instructions)
+    - [1. Create Service Principal [optional]](#1-create-service-principal-optional)
+    - [2. Customize azuredeploy.parameters file](#2-customize-azuredeployparameters-file)
+    - [3. Create Resource Group for solution](#3-create-resource-group-for-solution)
+    - [4. Execute the template deployment](#4-execute-the-template-deployment)
+  - [Post-Installation and Verification](#post-installation-and-verification)
+  - [Further information](#further-information)
+  - [Licensing](#licensing)
+  - [Contact](#contact)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # chef-automate-ha
 
 This Azure Quickstart provides an 'unmanaged' full installation of Chef Server configured for high availability mode and a separate instance of Chef Automate.
@@ -104,6 +123,10 @@ Once you have deployed the cluster, you should be able to SSH to it via the ```c
 ## Further information
 
 - To learn more about Chef, visit [learn.chef.io](https://learn.chef.io)
+
+## Design Decisions
+
+- See [./doc/architecture/decisions](doc/architecture/decisions) directory for a list of design decisions related to this code base.
 
 ## Licensing
 

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -118,6 +118,13 @@
         "description": "password"
       }
     },
+    "baseUrl": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/chef-partners/chef-automate-ha/master/",
+      "metadata": {
+        "description": "Base github URL for azure templates"
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -182,6 +189,7 @@
       "feCustomData": "[variables('customData').feCustomData]",
       "chefFEAvailName": "fe-avail",
       "autoComputerName": "chefautomate",
+      "automateComputerOsDiskSizeGB": 100,
       "chefAutoExtenName": "chef-auto-ex",
       "automateCustomData": "[variables('customData').automateCustomData]",
       "firstName": "[parameters('firstName')]",
@@ -240,7 +248,7 @@
       "followerCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_backend_install_script_follower) , '\n', '    path: /etc/chef-backend/chef-backend-install.sh\n', '    permissions: 0700\n'))]",
       "automateCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('chef_automate_install_script_base')) , '\n', '    path: /etc/delivery/chef-automate-install.sh\n', '    permissions: 0700\n'))]"
     },
-    "baseUrl": "https://raw.githubusercontent.com/chef-partners/chef-automate-ha/master/",
+    "baseUrl": "[parameters('baseUrl')]",
     "keyvaultResourcesURL": "[concat(variables('baseUrl'),'nested/keyvaultResource.json')]",
     "managedDisksResourcesURL": "[concat(variables('baseUrl'),'nested/managedDisksResource.json')]",
     "diagnosticStorageAccountResourcesURL": "[concat(variables('baseUrl'),'nested/diagnosticStorageAccountResource.json')]",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -240,7 +240,7 @@
       "followerCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_backend_install_script_follower) , '\n', '    path: /etc/chef-backend/chef-backend-install.sh\n', '    permissions: 0700\n'))]",
       "automateCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('chef_automate_install_script_base')) , '\n', '    path: /etc/delivery/chef-automate-install.sh\n', '    permissions: 0700\n'))]"
     },
-    "baseUrl": "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/chef-automate-ha/",
+    "baseUrl": "https://raw.githubusercontent.com/chef-partners/chef-automate-ha/master/",
     "keyvaultResourcesURL": "[concat(variables('baseUrl'),'nested/keyvaultResource.json')]",
     "managedDisksResourcesURL": "[concat(variables('baseUrl'),'nested/managedDisksResource.json')]",
     "diagnosticStorageAccountResourcesURL": "[concat(variables('baseUrl'),'nested/diagnosticStorageAccountResource.json')]",

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -15,7 +15,7 @@
             "value": "GEN-SSH-PUB-KEY"
         },
         "vmSize": {
-            "value": "Standard_F4s"
+            "value": "Standard_DS4_v2"
         },
         "chefServerDnsPrefix": {
             "value": "chefserver"

--- a/doc/architecture/decisions/0001-record-architecture-decisions.md
+++ b/doc/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2018-06-15
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.

--- a/doc/architecture/decisions/0001-record-architecture-decisions.md
+++ b/doc/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [1. Record architecture decisions](#1-record-architecture-decisions)
+  - [Status](#status)
+  - [Context](#context)
+  - [Decision](#decision)
+  - [Consequences](#consequences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # 1. Record architecture decisions
 
 Date: 2018-06-15

--- a/doc/architecture/decisions/0002-increase-hardware-specification-of-the-chefautomate-server.md
+++ b/doc/architecture/decisions/0002-increase-hardware-specification-of-the-chefautomate-server.md
@@ -1,0 +1,19 @@
+# 2. Increase hardware specification of the chefautomate server
+
+Date: 2018-06-15
+
+## Status
+
+Accepted
+
+## Context
+
+Since the creation of this template, the hardware requirments on the chefautomate server have increased to a minimum of 16Gb RAM and of >=80Gb free on /var.  The current ARM template did not meet these requirements and as a result the "automate-ctl preflight-check" was failing.
+
+## Decision
+
+Therefore, it was decided to increase the Azure VM size from Standard_F4s (with 8Gb RAM) to Standard_DS4_v2 (with 16Gb RAM) and the OS disk size from 30Gb to 100Gb.
+
+## Consequences
+
+Consequently, the automate-ctl preflight-check is passing and the server is ready by default for the setup of the automate server.

--- a/doc/architecture/decisions/0002-increase-hardware-specification-of-the-chefautomate-server.md
+++ b/doc/architecture/decisions/0002-increase-hardware-specification-of-the-chefautomate-server.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [2. Increase hardware specification of the chefautomate server](#2-increase-hardware-specification-of-the-chefautomate-server)
+  - [Status](#status)
+  - [Context](#context)
+  - [Decision](#decision)
+  - [Consequences](#consequences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # 2. Increase hardware specification of the chefautomate server
 
 Date: 2018-06-15

--- a/nested/fe-be-virtualmachines-with-extensions.json
+++ b/nested/fe-be-virtualmachines-with-extensions.json
@@ -592,7 +592,7 @@
           },
           "osDisk": {
             "createOption": "FromImage",
-            "diskSizeGB": 200
+            "diskSizeGB": "[parameters('computeSettings').automateComputerOsDiskSizeGB]"
           },
           "dataDisks": [
             {

--- a/nested/fe-be-virtualmachines-with-extensions.json
+++ b/nested/fe-be-virtualmachines-with-extensions.json
@@ -591,7 +591,8 @@
             "version": "[parameters('computeSettings').imageVersion]"
           },
           "osDisk": {
-            "createOption": "FromImage"
+            "createOption": "FromImage",
+            "diskSizeGB": 200
           },
           "dataDisks": [
             {


### PR DESCRIPTION
The main fixes in this PR are to satisfy [hardware requirements](https://docs.chef.io/install_chef_automate.html#hardware-requirements) on the chefautomate server:  RAM must be >= 16Gb, /var must have >= 80Gb free.  The RAM has been increased now from 8Gb Standard_F4s to 16Gb Standard_DS4_vs and the OS disk size from 30 to 100Gb to meet these requirements.

There are a couple minor changes to the baseUrl (the root of the template repo) variable in this PR as well: baseUrl was extracted as a parameter to ease testing and repointed from Azure's chef-automate-ha repository to Chef-Partner's one.