### PR TITLE
Add GUID to identify chef-automate-ha deployments with the "open source" provider

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -263,7 +263,7 @@
     "chefAutoPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').chefAutoPublicIPAddressName)]",
     "prefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name)]",
     "tags": {
-      "provider": "18d63047-6cdf-4f34-beed-62f01fc73fc2"
+      "provider": "2680257b-9f22-4261-b1ef-72412d367a68"
     }
   },
   "resources": [

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -261,9 +261,26 @@
     "feSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', variables('networkSettings').virtualNetworkName, variables('networkSettings').feSubnetName)]",
     "felbPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').felbPublicIPAddressName)]",
     "chefAutoPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').chefAutoPublicIPAddressName)]",
-    "prefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name)]"
+    "prefix": "[uniqueString(subscription().subscriptionId, resourceGroup().id, deployment().name)]",
+    "tags": {
+      "provider": "18d63047-6cdf-4f34-beed-62f01fc73fc2"
+    }
   },
   "resources": [
+    {
+      "comments": "Resource to track Chef Automate installations using this template",
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat('pid-', variables('tags').provider)]",
+      "apiVersion": "2017-05-10",  
+      "properties": {
+          "mode": "Incremental",
+          "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "resources": []
+          }
+      }
+    },
     {
       "name": "keyvaultResource",
       "type": "Microsoft.Resources/deployments",


### PR DESCRIPTION
### Changelog

* Added "open source" provider GUID to the chef-automat-ha deployment

Background for this change:  Chef needs to track chef automate deployments on azure, particularly whether the deployment is categorised into one of 3 provider groups either "open source", "commercial", or "partnerships".  To achieve this categorisation it was decided to (a) associate 3 unique GUIDs to each of the providers; and (b) create an empty resource group with a name that contains "pid-" plus the provider GUID.  This PR ensures that all chef-automate-ha quickstart deployments are tagged with the "open source" provider group